### PR TITLE
chore(pom): add logger implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,12 @@
       <groupId>org.camunda.bpm.dmn</groupId>
       <artifactId>camunda-engine-dmn</artifactId>
     </dependency>
+    <!-- logging -->
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.1.3</version>
+    </dependency>
   </dependencies>
 
   <properties>


### PR DESCRIPTION
I think it is more realistic to have a logger. Also slf4j doesn't interrupt the output complaining that no logger implementation was found.